### PR TITLE
VEGA-3204: [Tree] Фикс подсвечивания элементов с одинаковым ID

### DIFF
--- a/src/components/tree/TreeLeaf.tsx
+++ b/src/components/tree/TreeLeaf.tsx
@@ -75,9 +75,9 @@ export const TreeLeaf: React.FC<TreeItem> = (props) => {
         className={cnTree('NavigationItem', {
           Selected: selectedItems?.includes(targetData),
           AccessibleDropZone:
-            withDropZoneIndicator && dropZone && dropZone.id === id && dropZone.accessible,
+            withDropZoneIndicator && dropZone && dropZone.ref === targetRef && dropZone.accessible,
           InaccessibleDropZone:
-            withDropZoneIndicator && dropZone && dropZone.id === id && !dropZone.accessible,
+            withDropZoneIndicator && dropZone && dropZone.ref === targetRef && !dropZone.accessible,
           Hidden: visibilityIdentifier.isHidden,
         })}
         onClick={handleSelect}

--- a/src/components/tree/TreeNode.tsx
+++ b/src/components/tree/TreeNode.tsx
@@ -102,9 +102,15 @@ export const TreeNode: React.FC<TreeItem> = (props) => {
         className={cnTree('NavigationItem', {
           Selected: selectedItems?.includes(targetData),
           AccessibleDropZone:
-            withDropZoneIndicator && dropZone && dropZone.id === id && dropZone.accessible,
+            withDropZoneIndicator &&
+            dropZone &&
+            dropZone.ref === dropZoneRef &&
+            dropZone.accessible,
           InaccessibleDropZone:
-            withDropZoneIndicator && dropZone && dropZone.id === id && !dropZone.accessible,
+            withDropZoneIndicator &&
+            dropZone &&
+            dropZone.ref === dropZoneRef &&
+            !dropZone.accessible,
           Hidden: visibilityIdentifier.isHidden,
         })}
         onClick={handleSelect}


### PR DESCRIPTION
## Задача
Стенд: http://VEGA-3204.vega-ui-storybook.csssr.cloud
Cсылка в Jira CSSSR на задачу: https://jira.csssr.io/browse/VEGA-3204

Jira issue: VEGA-3204

## Описание изменений

- Исправлено одновременное dropZone-подчеркивание для элементов с одинаковым ID

## Чек-лист

- [x] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [x] PR: есть описание изменений или приложена ссылка на задачу с описанием, оставлены пояснительные комментарии к diff
- [x] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Сторибук: stories соответствует [правилам](https://github.com/gpn-prototypes/vega-ui/blob/master/docs/storybook.md)
- [ ] Верстка: используются [переменные](https://github.com/gpn-prototypes/ui-kit/tree/master/src/components/Theme) и [css-классы](https://github.com/gpn-prototypes/ui-kit/blob/master/src/utils/whitepaper/whitepaper.css) из [дизайн-системы ГПН](https://github.com/gpn-prototypes/ui-kit)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем PR
- [ ] Коммиты: проименованы в соответствии с [правилами](../docs/commits-style.md)
