### PR TITLE
VEGA-3372: [Tree] Добавление сохранения видимости для группы и элемента в дереве

### DIFF
--- a/src/components/tree/Tree.stories.tsx
+++ b/src/components/tree/Tree.stories.tsx
@@ -358,7 +358,7 @@ storiesOf('ui/Tree', module)
     return (
       <Tree
         icons={icons}
-        projectId="mock project id"
+        projectId="a3333333-b111-c111-d111-e00000000011"
         actionItemComponents={[<ActionItemComponent />]}
         isContextMenuEnable
         nodeList={sourceTree}

--- a/src/components/tree/Tree.stories.tsx
+++ b/src/components/tree/Tree.stories.tsx
@@ -284,12 +284,12 @@ export const rootProps: TreeItem[] = [
 const contextMenuItems: ContextMenuItem[] = [
   {
     title: (ref, state) => {
-      return state.hiddenItems?.includes(ref) ? 'Раскрыть слой' : 'Скрыть слой';
+      return state.hiddenItems?.find((item) => item.ref === ref) ? 'Раскрыть слой' : 'Скрыть слой';
     },
-    callback: (ref, actions) => {
-      action('Collapse')(ref);
+    callback: (item, actions) => {
+      action('Collapse')(item.ref);
       if (actions.onHideItem) {
-        actions.onHideItem(ref);
+        actions.onHideItem(item);
       }
     },
     withSeparator: true,

--- a/src/components/tree/Tree.stories.tsx
+++ b/src/components/tree/Tree.stories.tsx
@@ -358,6 +358,7 @@ storiesOf('ui/Tree', module)
     return (
       <Tree
         icons={icons}
+        projectId="mock project id"
         actionItemComponents={[<ActionItemComponent />]}
         isContextMenuEnable
         nodeList={sourceTree}

--- a/src/components/tree/Tree.test.tsx
+++ b/src/components/tree/Tree.test.tsx
@@ -108,9 +108,34 @@ describe('Tree', () => {
   });
 
   test('скрытые элементы Дерева, восстанавливаются после перезагрузки', async () => {
-    const props = {
+    const props: TreeProps = {
       nodeList: rootProps,
       projectId: mockProjectId,
+    };
+
+    const { rerender } = renderComponent(props);
+
+    const container = screen.getAllByRole('treeitem')[1];
+    const item = container.querySelector('[role="switch"]') as HTMLElement;
+
+    userEvent.click(item);
+
+    await waitFor(() => {
+      expect(container).toHaveClass('VegaTree__NavigationItem_Hidden');
+    });
+
+    rerender(<Tree {...props} />);
+
+    const containerAfterReload = screen.getAllByRole('treeitem')[1];
+
+    await waitFor(() => {
+      expect(containerAfterReload).toHaveClass('VegaTree__NavigationItem_Hidden');
+    });
+  });
+
+  test('скрытые элементы Дерева, восстанавливаются после перезагрузки, без указания projectId', async () => {
+    const props: TreeProps = {
+      nodeList: rootProps,
     };
 
     const { rerender } = renderComponent(props);
@@ -143,6 +168,37 @@ describe('Tree', () => {
 
     await waitFor(() => {
       expect(hiddenItems).toBeNull();
+    });
+  });
+
+  test('Вызывается onHideItem при переключении видимости элемента', async () => {
+    const onHideItemMock = jest.fn();
+
+    const props: TreeProps = {
+      nodeList: rootProps,
+      projectId: mockProjectId,
+      onHideItem: onHideItemMock,
+    };
+
+    renderComponent(props);
+
+    const container = screen.getAllByRole('treeitem')[1];
+    const item = container.querySelector('[role="switch"]') as HTMLElement;
+
+    userEvent.click(item);
+
+    await waitFor(() => {
+      expect(container).toHaveClass('VegaTree__NavigationItem_Hidden');
+    });
+
+    userEvent.click(item);
+
+    await waitFor(() => {
+      expect(container).not.toHaveClass('VegaTree__NavigationItem_Hidden');
+    });
+
+    await waitFor(() => {
+      expect(onHideItemMock).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/components/tree/Tree.tsx
+++ b/src/components/tree/Tree.tsx
@@ -7,7 +7,7 @@ import { useContextMenu } from './components/TreeContextMenu/use-context-menu';
 import cnTree from './cn-tree';
 import TreeContext from './context';
 import renderTree from './tree-creator';
-import { DropZone, HiddenItem, TargetData, TreeProps } from './types';
+import { ContextMenuTarget, DropZone, HiddenItem, TargetData, TreeProps } from './types';
 import { useHiddenItems } from './use-hidden-items';
 
 import './Tree.css';
@@ -39,9 +39,7 @@ export function Tree<T extends unknown>(
 
   const [isMultiSelect, setIsMultiSelect] = useState(false);
   const [selectedItems, setSelectedItems] = useState<Array<TargetData>>([]);
-  const [contextMenuTarget, setContextMenuTarget] = useState<React.RefObject<HTMLElement> | null>(
-    null,
-  );
+  const [contextMenuTarget, setContextMenuTarget] = useState<ContextMenuTarget | null>(null);
 
   const { hiddenItems, handleHideItem, handleRestoreHiddenItem } = useHiddenItems();
 
@@ -196,9 +194,9 @@ export function Tree<T extends unknown>(
     setDropZone(null);
   };
 
-  const handleContextMenu = (event: React.MouseEvent, ref: React.RefObject<HTMLElement>) => {
-    setContextMenuTarget(ref);
-    open(event, ref);
+  const handleContextMenu = (event: React.MouseEvent, target: ContextMenuTarget) => {
+    setContextMenuTarget(target);
+    open(event, target);
   };
 
   return (

--- a/src/components/tree/TreeLeaf.tsx
+++ b/src/components/tree/TreeLeaf.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useRef } from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 
 import cnTree from './cn-tree';
 import TreeContext from './context';
@@ -27,6 +27,7 @@ export const TreeLeaf: React.FC<TreeItem> = (props) => {
     onDragLeave,
     onDragOver,
     onDragDrop,
+    restoreHiddenItem,
     withDropZoneIndicator,
   } = useContext(TreeContext);
 
@@ -56,7 +57,17 @@ export const TreeLeaf: React.FC<TreeItem> = (props) => {
     onDragDrop,
   });
 
-  const visibilityIdentifier = useVisibilityIdentifier({ ref: targetRef, handleHide, hiddenItems });
+  useEffect(() => {
+    if (restoreHiddenItem) {
+      restoreHiddenItem({ id, ref: targetRef });
+    }
+  }, [id, restoreHiddenItem]);
+
+  const visibilityIdentifier = useVisibilityIdentifier({
+    item: { id, ref: targetRef },
+    handleHide,
+    hiddenItems,
+  });
 
   return (
     <TreeItemContainer

--- a/src/components/tree/TreeLeaf.tsx
+++ b/src/components/tree/TreeLeaf.tsx
@@ -15,7 +15,6 @@ export const TreeLeaf: React.FC<TreeItem> = (props) => {
 
   const {
     selectedItems,
-    hiddenItems,
     isDndEnable,
     dropZone,
     onHideItem,
@@ -27,7 +26,7 @@ export const TreeLeaf: React.FC<TreeItem> = (props) => {
     onDragLeave,
     onDragOver,
     onDragDrop,
-    restoreHiddenItem,
+    onRestoreHiddenItem,
     withDropZoneIndicator,
   } = useContext(TreeContext);
 
@@ -58,15 +57,14 @@ export const TreeLeaf: React.FC<TreeItem> = (props) => {
   });
 
   useEffect(() => {
-    if (restoreHiddenItem) {
-      restoreHiddenItem({ id, ref: targetRef });
+    if (onRestoreHiddenItem) {
+      onRestoreHiddenItem({ id, ref: targetRef });
     }
-  }, [id, restoreHiddenItem]);
+  }, [id, onRestoreHiddenItem]);
 
   const visibilityIdentifier = useVisibilityIdentifier({
     item: { id, ref: targetRef },
     handleHide,
-    hiddenItems,
   });
 
   return (

--- a/src/components/tree/TreeNode.tsx
+++ b/src/components/tree/TreeNode.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useLayoutEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import { IconArrowDown, IconArrowRight } from '../icons';
 
@@ -36,6 +36,7 @@ export const TreeNode: React.FC<TreeItem> = (props) => {
     onDragLeave,
     onDragOver,
     onDragDrop,
+    restoreHiddenItem,
     withDropZoneIndicator,
   } = useContext(TreeContext);
 
@@ -76,7 +77,17 @@ export const TreeNode: React.FC<TreeItem> = (props) => {
     onDragDrop,
   });
 
-  const visibilityIdentifier = useVisibilityIdentifier({ ref: targetRef, handleHide, hiddenItems });
+  useEffect(() => {
+    if (restoreHiddenItem) {
+      restoreHiddenItem({ id, ref: targetRef });
+    }
+  }, [id, restoreHiddenItem]);
+
+  const visibilityIdentifier = useVisibilityIdentifier({
+    item: { id, ref: targetRef },
+    handleHide,
+    hiddenItems,
+  });
 
   const handleToggleExpand = (event: React.MouseEvent | React.KeyboardEvent): void => {
     event.stopPropagation();

--- a/src/components/tree/TreeNode.tsx
+++ b/src/components/tree/TreeNode.tsx
@@ -24,7 +24,6 @@ export const TreeNode: React.FC<TreeItem> = (props) => {
   const {
     showIndentGuides,
     selectedItems,
-    hiddenItems,
     isDndEnable,
     dropZone,
     onHideItem,
@@ -36,7 +35,7 @@ export const TreeNode: React.FC<TreeItem> = (props) => {
     onDragLeave,
     onDragOver,
     onDragDrop,
-    restoreHiddenItem,
+    onRestoreHiddenItem,
     withDropZoneIndicator,
   } = useContext(TreeContext);
 
@@ -78,15 +77,14 @@ export const TreeNode: React.FC<TreeItem> = (props) => {
   });
 
   useEffect(() => {
-    if (restoreHiddenItem) {
-      restoreHiddenItem({ id, ref: targetRef });
+    if (onRestoreHiddenItem) {
+      onRestoreHiddenItem({ id, ref: targetRef });
     }
-  }, [id, restoreHiddenItem]);
+  }, [id, onRestoreHiddenItem]);
 
   const visibilityIdentifier = useVisibilityIdentifier({
     item: { id, ref: targetRef },
     handleHide,
-    hiddenItems,
   });
 
   const handleToggleExpand = (event: React.MouseEvent | React.KeyboardEvent): void => {

--- a/src/components/tree/components/TreeContextMenu/TreeContextMenuList.tsx
+++ b/src/components/tree/components/TreeContextMenu/TreeContextMenuList.tsx
@@ -17,8 +17,8 @@ const TreeContextMenuList: React.FC<ContextMenuListProps> = (props) => {
   return (
     <div className={cnTree('ContextMenuList')}>
       {items.map((item) => {
-        const title = contextMenuTarget?.current
-          ? item.title(contextMenuTarget, {
+        const title = contextMenuTarget?.ref?.current
+          ? item.title(contextMenuTarget.ref, {
               selectedItems,
               hiddenItems,
             })
@@ -29,7 +29,7 @@ const TreeContextMenuList: React.FC<ContextMenuListProps> = (props) => {
             label={title}
             aria-label={title}
             onClick={() => {
-              if (contextMenuTarget?.current) {
+              if (contextMenuTarget) {
                 item.callback(contextMenuTarget, {
                   onHideItem,
                   onSelectItem,

--- a/src/components/tree/components/TreeContextMenu/use-context-menu.tsx
+++ b/src/components/tree/components/TreeContextMenu/use-context-menu.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 
+import { ContextMenuTarget } from '../../types';
+
 type useContextMenuProps = {
   enabled: boolean;
 };
@@ -11,7 +13,7 @@ type contextMenuApi = {
     top: string | number;
   };
   isOpen: boolean;
-  open: (event: React.MouseEvent, ref: React.RefObject<HTMLElement>) => void;
+  open: (event: React.MouseEvent, target: ContextMenuTarget) => void;
   close: () => void;
 };
 
@@ -23,14 +25,14 @@ export const useContextMenu = ({ enabled }: useContextMenuProps): contextMenuApi
     top: string | number;
   }>({ left: 0, top: 0 });
 
-  const open = (event: React.MouseEvent, ref: React.RefObject<HTMLElement>): void => {
+  const open = (event: React.MouseEvent, target: ContextMenuTarget): void => {
     if (!enabled) {
       return;
     }
 
     event.preventDefault();
 
-    setCallerRef(ref);
+    setCallerRef(target.ref);
     setCoordinates({
       left: event.clientX,
       top: event.clientY,

--- a/src/components/tree/context.ts
+++ b/src/components/tree/context.ts
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import { DropZone, TargetData } from './types';
+import { DropZone, HiddenItem, TargetData } from './types';
 
 type TreeApi = {
   treeContainerWidth?: number | string;
   showIndentGuides: boolean;
   selectedItems: TargetData[];
-  hiddenItems: React.RefObject<HTMLElement>[] | null;
+  hiddenItems: HiddenItem[] | null;
   contextMenuTarget: React.RefObject<HTMLElement> | null;
   withVisibilitySwitcher?: boolean;
   withDropZoneIndicator?: boolean;
@@ -24,7 +24,8 @@ type TreeApi = {
   onDragEnd?(event: React.DragEvent): void;
   dropZone?: DropZone | null;
   onSelectItem?: (selectedItem: TargetData) => void;
-  onHideItem?: (ref: React.RefObject<HTMLElement | HTMLLIElement>) => void;
+  onHideItem?: (item: HiddenItem) => void;
+  restoreHiddenItem?: (item: HiddenItem) => void;
 };
 
 const TreeContext = React.createContext<TreeApi>({

--- a/src/components/tree/context.ts
+++ b/src/components/tree/context.ts
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import { DropZone, HiddenItem, TargetData } from './types';
+import { ContextMenuTarget, DropZone, HiddenItem, TargetData } from './types';
 
 type TreeApi = {
   treeContainerWidth?: number | string;
   showIndentGuides: boolean;
   selectedItems: TargetData[];
   hiddenItems: HiddenItem[] | null;
-  contextMenuTarget: React.RefObject<HTMLElement> | null;
+  contextMenuTarget: ContextMenuTarget | null;
   withVisibilitySwitcher?: boolean;
   withDropZoneIndicator?: boolean;
   actionItemComponents?: React.ReactElement[];
@@ -16,7 +16,7 @@ type TreeApi = {
   };
   isDndEnable: boolean;
   projectId?: string;
-  onContextMenu?(event: React.MouseEvent, ref: React.RefObject<HTMLElement>): void;
+  onContextMenu?(event: React.MouseEvent, target: ContextMenuTarget): void;
   onDragStart?(event: React.DragEvent, dragItem: TargetData): void;
   onDragEnter?(event: React.DragEvent, dropZoneItem: TargetData & { isDropZone: boolean }): void;
   onDragOver?(event: React.DragEvent): void;

--- a/src/components/tree/context.ts
+++ b/src/components/tree/context.ts
@@ -15,6 +15,7 @@ type TreeApi = {
     [iconId: string]: React.ReactElement;
   };
   isDndEnable: boolean;
+  projectId?: string;
   onContextMenu?(event: React.MouseEvent, ref: React.RefObject<HTMLElement>): void;
   onDragStart?(event: React.DragEvent, dragItem: TargetData): void;
   onDragEnter?(event: React.DragEvent, dropZoneItem: TargetData & { isDropZone: boolean }): void;
@@ -25,7 +26,7 @@ type TreeApi = {
   dropZone?: DropZone | null;
   onSelectItem?: (selectedItem: TargetData) => void;
   onHideItem?: (item: HiddenItem) => void;
-  restoreHiddenItem?: (item: HiddenItem) => void;
+  onRestoreHiddenItem?: (item: HiddenItem) => void;
 };
 
 const TreeContext = React.createContext<TreeApi>({

--- a/src/components/tree/entities/StateSaverService.test.ts
+++ b/src/components/tree/entities/StateSaverService.test.ts
@@ -1,0 +1,33 @@
+import { StateSaverService } from './StateSaverService';
+
+describe('ScreenSaverService', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  test('устанавливает и добавляет к ключам значение projectId', () => {
+    const stateSaverService = new StateSaverService();
+
+    const projectIds = ['test-1', 'test-2', 'test-3'];
+
+    projectIds.forEach((id) => {
+      stateSaverService.setProjectId(id);
+
+      const mockHiddenElements = ['mock id 1', 'mock id 2'];
+
+      stateSaverService.setHiddenElements(mockHiddenElements);
+
+      expect(stateSaverService.getHiddenElements()).toStrictEqual(mockHiddenElements);
+    });
+  });
+
+  test('Проставляет значения без savedScreenId', () => {
+    const stateSaverService = new StateSaverService();
+
+    const mockHiddenElements = ['mock id 1', 'mock id 2'];
+
+    stateSaverService.setHiddenElements(mockHiddenElements);
+
+    expect(stateSaverService.getHiddenElements()).toStrictEqual(mockHiddenElements);
+  });
+});

--- a/src/components/tree/entities/StateSaverService.ts
+++ b/src/components/tree/entities/StateSaverService.ts
@@ -1,0 +1,44 @@
+export type StorageNames = {
+  hiddenElements: string;
+};
+
+export class StateSaverService {
+  private readonly storageNames: StorageNames = {
+    hiddenElements: 'hiddenElements',
+  };
+
+  private projectId?: string;
+
+  setProjectId(projectId: string): void {
+    this.projectId = projectId;
+  }
+
+  private getStorageNames(): StorageNames {
+    if (this.projectId) {
+      return {
+        hiddenElements: `${this.storageNames.hiddenElements}-${this.projectId}`,
+      };
+    }
+
+    return this.storageNames;
+  }
+
+  setHiddenElements(hiddenElementsIds: string[]): void {
+    const { hiddenElements } = this.getStorageNames();
+
+    sessionStorage.setItem(hiddenElements, JSON.stringify(hiddenElementsIds));
+  }
+
+  getHiddenElements(): string[] {
+    const { hiddenElements } = this.getStorageNames();
+
+    const elements = sessionStorage.getItem(hiddenElements);
+    if (elements) {
+      return JSON.parse(elements);
+    }
+
+    return [];
+  }
+}
+
+export const stateSaverService = new StateSaverService();

--- a/src/components/tree/entities/StateSaverService.ts
+++ b/src/components/tree/entities/StateSaverService.ts
@@ -9,7 +9,7 @@ export class StateSaverService {
 
   private projectId?: string;
 
-  setProjectId(projectId: string): void {
+  setProjectId(projectId?: string): void {
     this.projectId = projectId;
   }
 
@@ -40,5 +40,3 @@ export class StateSaverService {
     return [];
   }
 }
-
-export const stateSaverService = new StateSaverService();

--- a/src/components/tree/types.ts
+++ b/src/components/tree/types.ts
@@ -30,14 +30,14 @@ export type ContextMenuItem = {
     ref: React.RefObject<HTMLElement>,
     actions: {
       onSelectItem?: (ref: TargetData) => void;
-      onHideItem?: (ref: RefObject<HTMLElement>) => void;
+      onHideItem?: (item: HiddenItem) => void;
     },
   ) => void;
   title: (
     ref: RefObject<HTMLElement>,
     state: {
       selectedItems: Array<TargetData>;
-      hiddenItems: Array<React.RefObject<HTMLElement>> | null;
+      hiddenItems: Array<HiddenItem> | null;
     },
   ) => string;
   key: string;

--- a/src/components/tree/types.ts
+++ b/src/components/tree/types.ts
@@ -27,7 +27,7 @@ export interface TreeItem<T = unknown> {
 
 export type ContextMenuItem = {
   callback: (
-    ref: React.RefObject<HTMLElement>,
+    item: HiddenItem,
     actions: {
       onSelectItem?: (ref: TargetData) => void;
       onHideItem?: (item: HiddenItem) => void;
@@ -46,7 +46,12 @@ export type ContextMenuItem = {
 
 export type HiddenItem = {
   id: string;
-  ref: RefObject<HTMLElement>;
+  ref: RefObject<HTMLElement> | null;
+};
+
+export type ContextMenuTarget = {
+  id: string;
+  ref: RefObject<HTMLElement> | null;
 };
 
 export type TreeProps<T = unknown> = {

--- a/src/components/tree/types.ts
+++ b/src/components/tree/types.ts
@@ -51,7 +51,7 @@ export type HiddenItem = {
 
 export type TreeProps<T = unknown> = {
   nodeList: TreeItem<T>[];
-  projectId: string;
+  projectId?: string;
   contextMenuItems?: ContextMenuItem[];
   icons?: {
     [iconId: string]: React.ReactElement;

--- a/src/components/tree/types.ts
+++ b/src/components/tree/types.ts
@@ -44,8 +44,14 @@ export type ContextMenuItem = {
   withSeparator?: boolean;
 };
 
+export type HiddenItem = {
+  id: string;
+  ref: RefObject<HTMLElement>;
+};
+
 export type TreeProps<T = unknown> = {
   nodeList: TreeItem<T>[];
+  projectId: string;
   contextMenuItems?: ContextMenuItem[];
   icons?: {
     [iconId: string]: React.ReactElement;
@@ -66,7 +72,7 @@ export type TreeProps<T = unknown> = {
   onDragStart?: (transferringElems: Array<TargetData>) => void;
   onDragEnd?: () => void;
   onSelectItem?: (items: TargetData[]) => void;
-  onHideItem?: (items: RefObject<HTMLElement>[]) => void;
+  onHideItem?: (items: HiddenItem[]) => void;
 };
 
 export type NavigationEyeProps = {

--- a/src/components/tree/use-hidden-items.test.tsx
+++ b/src/components/tree/use-hidden-items.test.tsx
@@ -1,0 +1,67 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import { StateSaverService } from './entities/StateSaverService';
+import { HiddenItem } from './types';
+import { useHiddenItems } from './use-hidden-items';
+
+describe('useHiddenItems', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  const mockItem = { id: 'mock id', ref: { current: null } } as HiddenItem;
+
+  test('восстановление состояния сохраненного скрытого элемента', () => {
+    const stateSaverService = new StateSaverService();
+    stateSaverService.setHiddenElements([mockItem.id]);
+
+    const { result } = renderHook(() => useHiddenItems());
+
+    expect(result.current.hiddenItems).toEqual([]);
+
+    act(() => {
+      result.current.handleRestoreHiddenItem(mockItem);
+    });
+
+    expect(result.current.hiddenItems).toEqual([mockItem]);
+  });
+
+  test('элемент добавляется в список скрытых', () => {
+    const stateSaverService = new StateSaverService();
+    expect(stateSaverService.getHiddenElements()).toEqual([]);
+
+    const { result } = renderHook(() => useHiddenItems());
+
+    expect(result.current.hiddenItems).toEqual([]);
+
+    act(() => {
+      result.current.handleHideItem(mockItem, jest.fn());
+    });
+
+    expect(result.current.hiddenItems).toEqual([mockItem]);
+    expect(stateSaverService.getHiddenElements()).toEqual([mockItem.id]);
+  });
+
+  test('элемент удаляется из списока скрытых', () => {
+    const stateSaverService = new StateSaverService();
+    expect(stateSaverService.getHiddenElements()).toEqual([]);
+
+    const { result } = renderHook(() => useHiddenItems());
+
+    expect(result.current.hiddenItems).toEqual([]);
+
+    act(() => {
+      result.current.handleHideItem(mockItem, jest.fn());
+    });
+
+    expect(result.current.hiddenItems).toEqual([mockItem]);
+    expect(stateSaverService.getHiddenElements()).toEqual([mockItem.id]);
+
+    act(() => {
+      result.current.handleHideItem(mockItem, jest.fn());
+    });
+
+    expect(result.current.hiddenItems).toEqual([]);
+    expect(stateSaverService.getHiddenElements()).toEqual([]);
+  });
+});

--- a/src/components/tree/use-hidden-items.ts
+++ b/src/components/tree/use-hidden-items.ts
@@ -1,0 +1,61 @@
+import { useContext, useState } from 'react';
+
+import { StateSaverService } from './entities/StateSaverService';
+import TreeContext from './context';
+import { HiddenItem } from './types';
+
+type UseHiddenItems = {
+  hiddenItems: HiddenItem[];
+  handleHideItem(item: HiddenItem, onHideItem: ((items: HiddenItem[]) => void) | undefined): void;
+  handleRestoreHiddenItem(item: HiddenItem): void;
+};
+
+export const useHiddenItems = (): UseHiddenItems => {
+  const { projectId } = useContext(TreeContext);
+
+  const [hiddenItems, setHiddenItems] = useState<HiddenItem[]>([]);
+
+  const stateSaverService = new StateSaverService();
+  stateSaverService.setProjectId(projectId);
+
+  const savedHiddenElements = stateSaverService.getHiddenElements();
+
+  const handleHideItem = (item: HiddenItem, onHideItem: (items: HiddenItem[]) => void): void => {
+    if (hiddenItems?.find((hiddenItem) => hiddenItem.id === item.id)) {
+      const newState = hiddenItems.filter((hiddenItem) => hiddenItem.id !== item.id);
+
+      setHiddenItems([...newState]);
+
+      stateSaverService.setHiddenElements(newState.map((hiddenItem) => hiddenItem.id));
+
+      if (onHideItem) {
+        onHideItem([...newState, item]);
+      }
+      return;
+    }
+
+    const newHiddenItems = [...hiddenItems, item];
+    setHiddenItems(newHiddenItems);
+
+    stateSaverService.setHiddenElements(newHiddenItems.map((hiddenItem) => hiddenItem.id));
+
+    if (onHideItem) {
+      onHideItem(newHiddenItems);
+    }
+  };
+
+  const handleRestoreHiddenItem = (item: HiddenItem) => {
+    if (
+      savedHiddenElements.includes(item.id) &&
+      !hiddenItems.find((hiddenItem) => hiddenItem.id === item.id)
+    ) {
+      setHiddenItems([...hiddenItems, item]);
+    }
+  };
+
+  return {
+    hiddenItems,
+    handleHideItem,
+    handleRestoreHiddenItem,
+  };
+};

--- a/src/components/tree/use-tree-handlers.tsx
+++ b/src/components/tree/use-tree-handlers.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { HiddenItem, TargetData } from './types';
+import { ContextMenuTarget, HiddenItem, TargetData } from './types';
 
 type UseTreeHandlersProps = {
   id: string;
@@ -11,7 +11,7 @@ type UseTreeHandlersProps = {
   dropZoneRef: React.RefObject<HTMLElement> | null;
   isDropZone: boolean;
 
-  onContextMenu?(event: React.MouseEvent, ref: React.RefObject<HTMLElement>): void;
+  onContextMenu?(event: React.MouseEvent, target: ContextMenuTarget): void;
 
   onDragStart?(event: React.DragEvent, dragItem: TargetData): void;
   onDragEnter?(event: React.DragEvent, dropZoneItem: TargetData & { isDropZone: boolean }): void;
@@ -79,7 +79,7 @@ export const useTreeHandlers = (props: UseTreeHandlersProps): TreeHandlersApi =>
     if (onContextMenu) {
       handleSelect(event);
 
-      onContextMenu(event, ref);
+      onContextMenu(event, { id, ref });
     }
   };
 

--- a/src/components/tree/use-tree-handlers.tsx
+++ b/src/components/tree/use-tree-handlers.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from 'react';
 
-import { TargetData } from './types';
+import { HiddenItem, TargetData } from './types';
 
 type UseTreeHandlersProps = {
   id: string;
   ref: React.RefObject<HTMLElement>;
   isDraggable: boolean;
-  onHideItem?: (ref: React.RefObject<HTMLElement | HTMLLIElement>) => void;
+  onHideItem?: (item: HiddenItem) => void;
   onSelectItem?: (selectedItem: TargetData) => void;
   dropZoneRef: React.RefObject<HTMLElement> | null;
   isDropZone: boolean;
@@ -63,7 +63,7 @@ export const useTreeHandlers = (props: UseTreeHandlersProps): TreeHandlersApi =>
     event.stopPropagation();
 
     if (onHideItem) {
-      onHideItem(ref);
+      onHideItem({ id, ref });
     }
   };
 

--- a/src/components/tree/use-visability-identifier.tsx
+++ b/src/components/tree/use-visability-identifier.tsx
@@ -38,14 +38,11 @@ export const useVisibilityIdentifier = ({
     }
 
     const isHiddenAsChild = hiddenItems?.some((_item) => {
-      const isValidElms =
-        _item.ref.current instanceof HTMLElement && item.ref.current instanceof HTMLElement;
-
-      if (!isValidElms) {
-        return undefined;
+      if (_item.ref?.current instanceof HTMLElement && item.ref?.current instanceof HTMLElement) {
+        return _item.ref?.current?.contains(item.ref?.current);
       }
 
-      return _item.ref.current?.contains(item.ref.current);
+      return undefined;
     });
 
     if (isHiddenAsChild) {

--- a/src/components/tree/use-visability-identifier.tsx
+++ b/src/components/tree/use-visability-identifier.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 
-import { stateSaverService } from './entities/StateSaverService';
 import cnTree from './cn-tree';
+import TreeContext from './context';
 import NavigationDot from './NavigationDotSvg';
 import TreeNavigationEye from './TreeNavigationEye';
 import { HiddenItem, NavigationEyeProps } from './types';
@@ -16,16 +16,14 @@ const parent = 'parent';
 type UseVisibilityIdentifier = {
   item: HiddenItem;
   handleHide: (event: React.MouseEvent | React.KeyboardEvent) => void;
-  hiddenItems?: HiddenItem[] | null;
 };
 type VisibilityIdentifierData = typeof children | typeof parent | null;
 
 export const useVisibilityIdentifier = ({
   item,
   handleHide,
-  hiddenItems,
 }: UseVisibilityIdentifier): VisibilityIdentifierAPI => {
-  const savedHiddenItemsIds = stateSaverService.getHiddenElements();
+  const { hiddenItems } = useContext(TreeContext);
 
   const [
     visibilityIdentifierData,
@@ -33,7 +31,7 @@ export const useVisibilityIdentifier = ({
   ] = useState<VisibilityIdentifierData | null>(null);
 
   useEffect(() => {
-    if (hiddenItems?.includes(item) || savedHiddenItemsIds.includes(item.id)) {
+    if (hiddenItems?.find((hiddenItem) => hiddenItem.id === item.id)) {
       setVisibilityIdentifierData(parent);
 
       return;
@@ -57,7 +55,7 @@ export const useVisibilityIdentifier = ({
     }
 
     setVisibilityIdentifierData(null);
-  }, [item, hiddenItems, savedHiddenItemsIds]);
+  }, [item, hiddenItems]);
 
   const renderVisibilitySwitcher = (): React.ReactElement<NavigationEyeProps> => {
     if (visibilityIdentifierData === children) {


### PR DESCRIPTION
## Задача
Стенд: http://VEGA-3372.vega-ui-storybook.csssr.cloud
Cсылка в Jira CSSSR на задачу: https://jira.csssr.io/browse/VEGA-3372

Jira issue: VEGA-3372

## Описание изменений

Добавлено сохранение состояния видимости групп и элементов дерева в session storage
## Чек-лист

- [x] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [x] PR: есть описание изменений или приложена ссылка на задачу с описанием, оставлены пояснительные комментарии к diff
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [x] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [x] Сторибук: для компонентов написаны или обновлены stories
- [ ] Сторибук: stories соответствует [правилам](https://github.com/gpn-prototypes/vega-ui/blob/master/docs/storybook.md)
- [ ] Верстка: используются [переменные](https://github.com/gpn-prototypes/ui-kit/tree/master/src/components/Theme) и [css-классы](https://github.com/gpn-prototypes/ui-kit/blob/master/src/utils/whitepaper/whitepaper.css) из [дизайн-системы ГПН](https://github.com/gpn-prototypes/ui-kit)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем PR
- [x] Коммиты: проименованы в соответствии с [правилами](../docs/commits-style.md)
