### PR TITLE
[VEGA-5329]: added rich text opt on node item labels

### DIFF
--- a/src/components/tree/Tree.css
+++ b/src/components/tree/Tree.css
@@ -79,6 +79,10 @@
 
     white-space: nowrap;
     text-overflow: ellipsis;
+
+    &_Rich {
+      font-weight: 700;
+    }
   }
 
   &__Backlight {

--- a/src/components/tree/Tree.stories.tsx
+++ b/src/components/tree/Tree.stories.tsx
@@ -76,6 +76,7 @@ export const rootProps: TreeItem[] = [
         id: '2',
         parentId: '1',
         isDraggable: false,
+        rich: true,
         nodeList: [
           {
             name: 'Залежь - 78',
@@ -96,6 +97,7 @@ export const rootProps: TreeItem[] = [
                     isDraggable: false,
                     parentId: '21',
                     nodeList: [],
+                    rich: true,
                   },
                 ],
               },
@@ -357,6 +359,7 @@ storiesOf('ui/Tree', module)
 
     return (
       <Tree
+      withMultiSelect
         withCheckElementSwitcher
         icons={icons}
         projectId="a3333333-b111-c111-d111-e00000000011"

--- a/src/components/tree/TreeItemContent.tsx
+++ b/src/components/tree/TreeItemContent.tsx
@@ -8,9 +8,28 @@ export type TreeItemContentProps = JSX.IntrinsicElements['div'] & {
   iconId?: string | number;
   name?: string;
   children?: React.ReactNode;
+  labelKind?: TreeItemLabelKind;
   renderVisibilitySwitcher?: () => React.ReactElement;
   renderCheckedSwitcher?: () => React.ReactElement;
 };
+
+export type TreeItemLabelKind = "normal" | "rich";
+
+type TreeItemLabelProps = JSX.IntrinsicElements['div'] & {
+  kind?: TreeItemLabelKind;
+  text?: string;
+};
+
+export const TreeItemLabel = (props: TreeItemLabelProps): React.ReactElement => {
+  const {
+    kind = 'normal',
+    text,
+  } = props;
+
+  return (
+    <div className={cnTree('ItemName', { Rich: kind === 'rich' })}>{text}</div>
+  );
+}
 
 export const TreeItemContent = (props: TreeItemContentProps): React.ReactElement => {
   const {
@@ -18,6 +37,7 @@ export const TreeItemContent = (props: TreeItemContentProps): React.ReactElement
     className,
     children,
     iconId,
+    labelKind,
     name,
     renderVisibilitySwitcher,
     renderCheckedSwitcher,
@@ -45,7 +65,8 @@ export const TreeItemContent = (props: TreeItemContentProps): React.ReactElement
       <div className={cnTree('checkBox')}>
         {withCheckElementSwitcher && renderCheckedSwitcher && renderCheckedSwitcher()}
       </div>
-      <div className={cnTree('ItemName')}>{name}</div>
+
+      <TreeItemLabel className={cnTree('ItemName')} kind={labelKind} text={name} />
 
       <div
         className={cnTree('Backlight')}

--- a/src/components/tree/TreeLeaf.tsx
+++ b/src/components/tree/TreeLeaf.tsx
@@ -10,7 +10,14 @@ import { useTreeHandlers } from './use-tree-handlers';
 import { useVisibilityIdentifier } from './use-visibility-identifier';
 
 export const TreeLeaf: React.FC<TreeItem> = (props) => {
-  const { id, name, isDraggable = true, iconId, isDropZone = true } = props;
+  const {
+    id,
+    name,
+    isDraggable = true,
+    iconId,
+    isDropZone = true,
+    rich = false,
+  } = props;
 
   const targetRef = useRef<HTMLLIElement | null>(null);
 
@@ -101,6 +108,7 @@ export const TreeLeaf: React.FC<TreeItem> = (props) => {
         onClick={handleSelect}
         name={name}
         iconId={iconId}
+        labelKind={rich === true ? 'rich' : 'normal'}
         renderVisibilitySwitcher={visibilityIdentifier.renderVisibilitySwitcher}
         renderCheckedSwitcher={checkedElementIdentifier.renderCheckedSwitcher}
       />

--- a/src/components/tree/TreeNode.tsx
+++ b/src/components/tree/TreeNode.tsx
@@ -20,6 +20,7 @@ export const TreeNode: React.FC<TreeItem> = (props) => {
     isDropZone = true,
     iconId,
     isExpanded = false,
+    rich = false,
   } = props;
 
   const {
@@ -133,6 +134,7 @@ export const TreeNode: React.FC<TreeItem> = (props) => {
         onClick={handleSelect}
         name={name}
         iconId={iconId}
+        labelKind={rich === true ? 'rich' : 'normal'}
         renderVisibilitySwitcher={visibilityIdentifier.renderVisibilitySwitcher}
         renderCheckedSwitcher={checkedElementIdentifier.renderCheckedSwitcher}
       >

--- a/src/components/tree/tree-creator.tsx
+++ b/src/components/tree/tree-creator.tsx
@@ -17,6 +17,7 @@ const renderTree = (t: TreeItem[]): React.ReactElement[] => {
           isDraggable={node.isDraggable}
           isDropZone={node.isDropZone}
           isExpanded={node.isExpanded}
+          rich={node.rich}
         >
           {node.nodeList && renderTree(node.nodeList)}
         </TreeNode>
@@ -36,6 +37,7 @@ const renderTree = (t: TreeItem[]): React.ReactElement[] => {
         isDraggable={node.isDraggable}
         isDropZone={node.isDropZone}
         nodeList={[]}
+        rich={node.rich}
       />,
     );
 

--- a/src/components/tree/types.ts
+++ b/src/components/tree/types.ts
@@ -22,6 +22,7 @@ export interface TreeItem<T = unknown> {
   isDraggable?: boolean;
   isDropZone?: boolean;
   isExpanded?: boolean;
+  rich?: boolean;
   data?: T;
 }
 


### PR DESCRIPTION
## Problem statement

[VEGA-5329](https://artcpt.atlassian.net/browse/VEGA-5329)

## Solution details

Появилась возможность выбора жирного выделения шрифта текста у одного или нескольких элементов `TreeNode` / `TreeLeaf` компонента `Tree`. Управление осуществляется через свойство `rich: boolean` элемента списка `nodeList`, передаваемого в `Tree`. 

Пример среза дерева с rich-элементами:
![image](https://user-images.githubusercontent.com/21131990/169752918-3d81e35e-6dd1-4c39-907d-4e4a5e14357d.png)


## Type
- [x] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Test
- [ ] Other

## Associated issues

_{Jira issues or PRs related to this one}_

## Quality control
- [x] PR: Based on a correct branch
- [x] PR: Head branch is rebased on the base branch
- [x] PR: Assignee chosen and necessary labels are set
- [x] PR: Current form is filled out (where it makes sense)
- [x] PR: Diff checked for irrelevant changes
- [x] PR: Commit messages follow [the rules](../docs/commits-style.md)
- [x] JS: There's no errors/warnings in the browser dev console
- [x] Layout: Uses [variables](https://github.com/gpn-prototypes/ui-kit/tree/master/src/components/Theme) and [CSS classes](https://github.com/gpn-prototypes/ui-kit/blob/master/src/utils/whitepaper/whitepaper.css) from [GPN design system](https://github.com/gpn-prototypes/ui-kit)
- [x] Layout: Tested with various content amounts
- [ ] Docs: All changes to the component API are reflected and key points are described
- [ ] Storybook: Stories are written/updated for components
- [ ] Storybook: Stories follow [the rules](https://github.com/gpn-prototypes/vega-ui/blob/master/docs/storybook.md)
- [ ] Tests: New features and bugfixes are covered with tests
- [ ] Tests: Existing tests passed successfully

## Notable statements
- [ ] Affects configuration files
- [ ] Brings new packages or updates existing
- [ ] Opened follow-up tasks to resolve
